### PR TITLE
Apply options after connection is made

### DIFF
--- a/thirdparty/Zend/Cache/Backend/Redis.php
+++ b/thirdparty/Zend/Cache/Backend/Redis.php
@@ -95,10 +95,23 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
         }
 
         parent::__construct($options);
-		
+
         $this->_redis = new Redis();
 
-        // setup memcached client options
+
+		$server = array();
+
+		$server = $this->_options['server'];
+		if (!array_key_exists('port', $server)){
+			$server['port'] = self::DEFAULT_PORT;
+        }
+		if (!array_key_exists('timeout', $server)) {
+            $server['timeout'] = self::DEFAULT_TIMEOUT;
+        }
+
+		$this->_redis->connect($server['host'], $server['port'], $server['timeout']);
+
+        // setup redis client options this occurs after connection due to this https://github.com/phpredis/phpredis/issues/504
         foreach ($this->_options['client'] as $name => $value) {
             $optId = null;
             if (is_int($name)) {
@@ -117,18 +130,6 @@ class Zend_Cache_Backend_Redis extends Zend_Cache_Backend implements Zend_Cache_
                 }
             }
         }
-		
-		$server = array();
-		
-		$server = $this->_options['server'];
-		if (!array_key_exists('port', $server)){
-			$server['port'] = self::DEFAULT_PORT;
-        }
-		if (!array_key_exists('timeout', $server)) {
-            $server['timeout'] = self::DEFAULT_TIMEOUT;
-        }
-		
-		$this->_redis->connect($server['host'], $server['port'], $server['timeout']);
     }
 
     /**


### PR DESCRIPTION
This https://github.com/phpredis/phpredis/issues/504 bug appears to still be in the latest released version of phpredis.

Basically by apply the options after the connection is made the bug is bypassed